### PR TITLE
Fix dbfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Online real-time collaborative LaTeX editor
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.overleaf.com)
-[![Version: 2026.06.26~ynh1](https://img.shields.io/badge/Version-2026.06.26~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/overleaf/)
+[![Version: 2026.06.26~ynh2](https://img.shields.io/badge/Version-2026.06.26~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/overleaf/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/overleaf"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Overleaf"
 description.en = "Online real-time collaborative LaTeX editor"
 description.fr = "Éditeur LaTeX collaboratif en ligne et en temps réel"
 
-version = "2026.06.26~ynh1"
+version = "2026.06.26~ynh2"
 
 maintainers = []
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -125,6 +125,11 @@ then
     mv $data_dir/user_files $data_dir/old_user_files
 fi
 
+# add analyticsId field in db - versions <2026.06.26
+if ynh_app_upgrading_from_version_before 2026.06.26~ynh2
+then
+ 	ynh_mongo_exec --database="$db_name" --command='db.users.updateMany({ analyticsId: { $exists: false } }, [{ $set: { analyticsId: { $toString: "$_id" } } }, ])'
+fi
 
 #=================================================
 # CONFIGURE TEXLIVE


### PR DESCRIPTION
Fix for https://forum.yunohost.org/t/impossible-de-se-connecter-a-overleaf-unable-to-log-into-overleaf/42536

- I installed version = "`2026.06.05~ynh1`" and created admin user.
- Upgrade to `2026.06.26~ynh1` caused the following issue : unable to authenticate with user created with 2026.06.05~ynh1.
- `"err":{"message":"bug: include db.users.analyticsId in projection","name":"Error","stack":"Error: bug: include db.users.analyticsId in projection\n    at _getIdsFromMongoUser (file:///var/www/overleaf/services/web/app/src/Features/Analytics/AnalyticsManager.mjs:526:11)\n    at Object.recordEventForMongoUserInBackground (file:///var/www/overleaf/services/web/app/src/Features/Analytics/AnalyticsManager.mjs:116:22)`
-> missing field `analyticsId` for users collection in db
- Upgrade to `2026.06.26~ynh2` :  can authenticate with user created with 2026.06.05~ynh1.
- patch based on [upstream migration](https://github.com/overleaf/overleaf/blob/main/tools/migrations/20260616070000_back_fill_users_analyticsId.mjs)
:warning: only tested once